### PR TITLE
Include song "discNumber"

### DIFF
--- a/beetsplug/beetstream/utils.py
+++ b/beetsplug/beetstream/utils.py
@@ -158,7 +158,8 @@ def map_song(song):
         # "starred": "2019-10-23T04:41:17.107Z",
         "albumId": album_beetid_to_subid(str(song["album_id"])),
         "artistId": artist_name_to_id(song["albumartist"]),
-        "type": "music"
+        "type": "music",
+        "discNumber": song["disc"]
     }
 
 def map_song_xml(xml, song):
@@ -186,6 +187,8 @@ def map_song_xml(xml, song):
     xml.set("albumId", album_beetid_to_subid(str(song["album_id"])))
     xml.set("artistId", artist_name_to_id(song["albumartist"]))
     xml.set("type", "music")
+    if song["disc"]:
+        xml.set("discNumber", str(song["disc"]))
 
 def map_artist(artist_name):
     return {


### PR DESCRIPTION
Version 1.8.0 of the Subsonic API added a `discNumber` field to the `song` element. This PR populates that field when the beets item has the `disc` field set.

Without this field clients can't sort multi-disc album tracks correctly.