### PR TITLE
Transcode the stream if ffmpeg-python is available

### DIFF
--- a/beetsplug/beetstream/songs.py
+++ b/beetsplug/beetstream/songs.py
@@ -53,10 +53,12 @@ def stream_song():
     id = int(song_subid_to_beetid(request.values.get('id')))
     item = g.lib.get_item(id)
 
-    if maxBitrate > 0 and item.bitrate > maxBitrate * 1000:
-        return stream.try_to_transcode(item.path.decode('utf-8'), maxBitrate)
+    itemPath = item.path.decode('utf-8')
+
+    if maxBitrate <= 0 or item.bitrate <= maxBitrate * 1000:
+        return stream.send_raw_file(itemPath)
     else:
-        return stream.send_raw_file(item.path.decode('utf-8'))
+        return stream.try_to_transcode(itemPath, maxBitrate)
 
 @app.route('/rest/download', methods=["GET", "POST"])
 @app.route('/rest/download.view', methods=["GET", "POST"])

--- a/beetsplug/beetstream/songs.py
+++ b/beetsplug/beetstream/songs.py
@@ -1,6 +1,5 @@
 from beetsplug.beetstream.utils import *
-from beetsplug.beetstream.stream import stream
-from beetsplug.beetstream import app
+from beetsplug.beetstream import app, stream
 from flask import g, request, Response
 from beets.random import random_objs
 import xml.etree.cElementTree as ET
@@ -54,7 +53,10 @@ def stream_song():
     id = int(song_subid_to_beetid(request.values.get('id')))
     item = g.lib.get_item(id)
 
-    return stream(item.path.decode('utf-8'), maxBitrate)
+    if maxBitrate > 0 and item.bitrate > maxBitrate * 1000:
+        return stream.try_to_transcode(item.path.decode('utf-8'), maxBitrate)
+    else:
+        return stream.send_raw_file(item.path.decode('utf-8'))
 
 @app.route('/rest/download', methods=["GET", "POST"])
 @app.route('/rest/download.view', methods=["GET", "POST"])
@@ -62,7 +64,7 @@ def download_song():
     id = int(song_subid_to_beetid(request.values.get('id')))
     item = g.lib.get_item(id)
 
-    return stream(item.path.decode('utf-8'), 0)
+    return stream.send_raw_file(item.path.decode('utf-8'))
 
 @app.route('/rest/getRandomSongs', methods=["GET", "POST"])
 @app.route('/rest/getRandomSongs.view', methods=["GET", "POST"])

--- a/beetsplug/beetstream/songs.py
+++ b/beetsplug/beetstream/songs.py
@@ -47,7 +47,7 @@ def songs_by_genre():
 @app.route('/rest/stream', methods=["GET", "POST"])
 @app.route('/rest/stream.view', methods=["GET", "POST"])
 def stream_song():
-    maxBitrate = int(request.values.get('maxBitRate') or 0) # TODO
+    maxBitrate = int(request.values.get('maxBitRate') or 0)
     format = request.values.get('format') #TODO
 
     id = int(song_subid_to_beetid(request.values.get('id')))

--- a/beetsplug/beetstream/songs.py
+++ b/beetsplug/beetstream/songs.py
@@ -54,7 +54,7 @@ def stream_song():
     id = int(song_subid_to_beetid(request.values.get('id')))
     item = g.lib.get_item(id)
 
-    return stream(item.path, maxBitrate)
+    return stream(item.path.decode('utf-8'), maxBitrate)
 
 @app.route('/rest/download', methods=["GET", "POST"])
 @app.route('/rest/download.view', methods=["GET", "POST"])
@@ -62,7 +62,7 @@ def download_song():
     id = int(song_subid_to_beetid(request.values.get('id')))
     item = g.lib.get_item(id)
 
-    return stream(item.path, 0)
+    return stream(item.path.decode('utf-8'), 0)
 
 @app.route('/rest/getRandomSongs', methods=["GET", "POST"])
 @app.route('/rest/getRandomSongs.view', methods=["GET", "POST"])

--- a/beetsplug/beetstream/songs.py
+++ b/beetsplug/beetstream/songs.py
@@ -1,4 +1,5 @@
 from beetsplug.beetstream.utils import *
+from beetsplug.beetstream.stream import stream
 from beetsplug.beetstream import app
 from flask import g, request, Response
 from beets.random import random_objs
@@ -49,24 +50,19 @@ def songs_by_genre():
 def stream_song():
     maxBitrate = int(request.values.get('maxBitRate') or 0) # TODO
     format = request.values.get('format') #TODO
-    return stream(maxBitrate)
+
+    id = int(song_subid_to_beetid(request.values.get('id')))
+    item = g.lib.get_item(id)
+
+    return stream(item.path, maxBitrate)
 
 @app.route('/rest/download', methods=["GET", "POST"])
 @app.route('/rest/download.view', methods=["GET", "POST"])
 def download_song():
-    return stream(0)
-
-def stream(maxBitrate):
     id = int(song_subid_to_beetid(request.values.get('id')))
     item = g.lib.get_item(id)
 
-    def generate():
-        with open(item.path, "rb") as songFile:
-            data = songFile.read(1024)
-            while data:
-                yield data
-                data = songFile.read(1024)
-    return Response(generate(), mimetype=path_to_content_type(item.path.decode('utf-8')))
+    return stream(item.path, 0)
 
 @app.route('/rest/getRandomSongs', methods=["GET", "POST"])
 @app.route('/rest/getRandomSongs.view', methods=["GET", "POST"])

--- a/beetsplug/beetstream/songs.py
+++ b/beetsplug/beetstream/songs.py
@@ -48,14 +48,14 @@ def songs_by_genre():
 @app.route('/rest/stream.view', methods=["GET", "POST"])
 def stream_song():
     maxBitrate = int(request.values.get('maxBitRate') or 0)
-    format = request.values.get('format') #TODO
+    format = request.values.get('format')
 
     id = int(song_subid_to_beetid(request.values.get('id')))
     item = g.lib.get_item(id)
 
     itemPath = item.path.decode('utf-8')
 
-    if maxBitrate <= 0 or item.bitrate <= maxBitrate * 1000:
+    if format == 'raw' or maxBitrate <= 0 or item.bitrate <= maxBitrate * 1000:
         return stream.send_raw_file(itemPath)
     else:
         return stream.try_to_transcode(itemPath, maxBitrate)

--- a/beetsplug/beetstream/stream.py
+++ b/beetsplug/beetstream/stream.py
@@ -1,12 +1,19 @@
 from beetsplug.beetstream.utils import path_to_content_type
 from flask import send_file, Response
 
-import ffmpeg
+import importlib
+have_ffmpeg = importlib.util.find_spec("ffmpeg") is not None
+
+if have_ffmpeg:
+    import ffmpeg
 
 def send_raw_file(filePath):
     return send_file(filePath, mimetype=path_to_content_type(filePath))
 
 def transcode_and_stream(filePath, maxBitrate):
+    if not have_ffmpeg:
+        raise RuntimeError("Can't transcode, ffmpeg-python is not available")
+
     outputStream = (
         ffmpeg
         .input(filePath)
@@ -17,4 +24,7 @@ def transcode_and_stream(filePath, maxBitrate):
     return Response(outputStream.stdout, mimetype='audio/mpeg')
 
 def try_to_transcode(filePath, maxBitrate):
-    return transcode_and_stream(filePath, maxBitrate)
+    if have_ffmpeg:
+        return transcode_and_stream(filePath, maxBitrate)
+    else:
+        return send_raw_file(filePath)

--- a/beetsplug/beetstream/stream.py
+++ b/beetsplug/beetstream/stream.py
@@ -1,0 +1,12 @@
+from beetsplug.beetstream.utils import path_to_content_type
+from flask import Response
+
+def stream(filePath, maxBitrate):
+    def generate():
+        with open(filePath, "rb") as songFile:
+            data = songFile.read(1024)
+            while data:
+                yield data
+                data = songFile.read(1024)
+
+    return Response(generate(), mimetype=path_to_content_type(filePath.decode('utf-8')))

--- a/beetsplug/beetstream/stream.py
+++ b/beetsplug/beetstream/stream.py
@@ -18,7 +18,7 @@ def transcode_and_stream(filePath, maxBitrate):
         ffmpeg
         .input(filePath)
         .output('pipe:', format="mp3", audio_bitrate=maxBitrate * 1000)
-        .run_async(pipe_stdout=True)
+        .run_async(pipe_stdout=True, quiet=True)
     )
 
     return Response(outputStream.stdout, mimetype='audio/mpeg')

--- a/beetsplug/beetstream/stream.py
+++ b/beetsplug/beetstream/stream.py
@@ -1,8 +1,20 @@
 from beetsplug.beetstream.utils import path_to_content_type
 from flask import send_file, Response
 
+import ffmpeg
+
 def send_raw_file(filePath):
     return send_file(filePath, mimetype=path_to_content_type(filePath))
 
-def stream(filePath, maxBitrate):
-    return send_raw_file(filePath)
+def transcode_and_stream(filePath, maxBitrate):
+    outputStream = (
+        ffmpeg
+        .input(filePath)
+        .output('pipe:', format="mp3", audio_bitrate=maxBitrate * 1000)
+        .run_async(pipe_stdout=True)
+    )
+
+    return Response(outputStream.stdout, mimetype='audio/mpeg')
+
+def try_to_transcode(filePath, maxBitrate):
+    return transcode_and_stream(filePath, maxBitrate)

--- a/beetsplug/beetstream/stream.py
+++ b/beetsplug/beetstream/stream.py
@@ -1,12 +1,8 @@
 from beetsplug.beetstream.utils import path_to_content_type
-from flask import Response
+from flask import send_file, Response
+
+def send_raw_file(filePath):
+    return send_file(filePath, mimetype=path_to_content_type(filePath))
 
 def stream(filePath, maxBitrate):
-    def generate():
-        with open(filePath, "rb") as songFile:
-            data = songFile.read(1024)
-            while data:
-                yield data
-                data = songFile.read(1024)
-
-    return Response(generate(), mimetype=path_to_content_type(filePath.decode('utf-8')))
+    return send_raw_file(filePath)


### PR DESCRIPTION
If the `ffmpeg` module (https://github.com/kkroening/ffmpeg-python) is available, transcode the output of `/rest/stream` to respect `maxBitRate`.

If ffmpeg is not available, it will fall back sending the raw file.

I also changed the code for sending the raw file to use `flask.send_file` - this is supposed to be more efficient.

I've tested this manually, with & without ffmpeg. I'm not sure this is the most effective way to transcode, but it's been working for me.