### PR TITLE
list top artists/playlist, add mime types, fallback to default mime type

### DIFF
--- a/beetsplug/beetstream/__init__.py
+++ b/beetsplug/beetstream/__init__.py
@@ -80,7 +80,10 @@ class BeetstreamPlugin(BeetsPlugin):
             app.config['never_transcode'] = self.config['never_transcode']
             playlist_dir = self.config['playlist_dir']
             if not playlist_dir:
-                playlist_dir = config['smartplaylist']['playlist_dir'].get()
+                try:
+                    playlist_dir = config['smartplaylist']['playlist_dir'].get()
+                except:
+                    pass
             app.config['playlist_dir'] = playlist_dir
 
             # Enable CORS if required.

--- a/beetsplug/beetstream/playlistprovider.py
+++ b/beetsplug/beetstream/playlistprovider.py
@@ -20,6 +20,8 @@ class PlaylistProvider:
         app.logger.debug(f"Loaded {len(self._playlists)} playlists")
 
     def _load_playlists(self):
+        if not self.dir:
+            return
         paths = glob.glob(os.path.join(self.dir, "**.m3u8"))
         paths += glob.glob(os.path.join(self.dir, "**.m3u"))
         paths.sort()

--- a/beetsplug/beetstream/playlistprovider.py
+++ b/beetsplug/beetstream/playlistprovider.py
@@ -3,6 +3,7 @@ import os
 import pathlib
 import re
 import sys
+from beetsplug.beetstream.utils import strip_accents
 from flask import current_app as app
 from werkzeug.utils import safe_join
 
@@ -91,7 +92,7 @@ def _sortedartists(artists):
 
 class Artist:
     def __init__(self, name):
-        self.key = name.lower()
+        self.key = strip_accents(name.lower())
         self.name = name
         self.count = 1
 

--- a/beetsplug/beetstream/playlists.py
+++ b/beetsplug/beetstream/playlists.py
@@ -49,5 +49,8 @@ def _song(id):
     return map_song(g.lib.get_item(int(id)))
 
 def playlist_provider():
-    _playlist_provider.dir = app.config['playlist_dir']
+    if 'playlist_dir' in app.config:
+        _playlist_provider.dir = app.config['playlist_dir']
+    if not _playlist_provider.dir:
+        app.logger.warning('No playlist_dir configured')
     return _playlist_provider

--- a/beetsplug/beetstream/playlists.py
+++ b/beetsplug/beetstream/playlists.py
@@ -49,5 +49,5 @@ def _song(id):
     return map_song(g.lib.get_item(int(id)))
 
 def playlist_provider():
-    _playlist_provider._dir = app.config['playlist_dir']
+    _playlist_provider.dir = app.config['playlist_dir']
     return _playlist_provider

--- a/beetsplug/beetstream/utils.py
+++ b/beetsplug/beetstream/utils.py
@@ -11,11 +11,15 @@ import xml.etree.cElementTree as ET
 from math import ceil
 from xml.dom import minidom
 
+DEFAULT_MIME_TYPE = 'application/octet-stream'
 EXTENSION_TO_MIME_TYPE_FALLBACK = {
     '.aac'  : 'audio/aac',
     '.flac' : 'audio/flac',
     '.mp3'  : 'audio/mpeg',
+    '.mp4'  : 'audio/mp4',
+    '.m4a'  : 'audio/mp4',
     '.ogg'  : 'audio/ogg',
+    '.opus' : 'audio/opus',
 }
 
 def strip_accents(s):
@@ -259,7 +263,9 @@ def path_to_content_type(path):
     if result:
         return result
 
-    raise RuntimeError(f"Unable to determine content type for {path}")
+    flask.current_app.logger.warning(f"No mime type mapped for {ext} extension: {path}")
+
+    return DEFAULT_MIME_TYPE
 
 def handleSizeAndOffset(collection, size, offset):
     if size is not None:

--- a/beetsplug/beetstream/utils.py
+++ b/beetsplug/beetstream/utils.py
@@ -214,6 +214,7 @@ def map_playlist(playlist):
         'name': playlist.name,
         'songCount': playlist.count,
         'duration': playlist.duration,
+        'comment': playlist.artists,
         'created': timestamp_to_iso(playlist.modified),
     }
 
@@ -222,6 +223,7 @@ def map_playlist_xml(xml, playlist):
     xml.set('name', playlist.name)
     xml.set('songCount', str(playlist.count))
     xml.set('duration', str(ceil(playlist.duration)))
+    xml.set('comment', playlist.artists)
     xml.set('created', timestamp_to_iso(playlist.modified))
 
 def artist_name_to_id(name):


### PR DESCRIPTION
* Aggregates the top artists per playlist and exposes them comma-separated within the `comment` field of each playlist. Also optimizes direct/single playlist access.
* Map mime types for m4a, mp4 and opus file extensions.
* When no mime type registered for file extension, fallback to serving the file using mime type `application/octet-stream` (and log a warning) instead of failing the request. (At least GStreamer/Mopidy seems to do its own format detection anyway since it still plays such streams.)